### PR TITLE
Expected semicolon ; after "}"

### DIFF
--- a/js/tm/lib/event.simulate.js
+++ b/js/tm/lib/event.simulate.js
@@ -13,7 +13,7 @@
   var eventMatchers = {
     'HTMLEvents': /^(?:load|unload|abort|error|select|change|submit|reset|focus|blur|resize|scroll)$/,
     'MouseEvents': /^(?:click|dblclick|mouse(?:down|up|over|move|out))$/
-  }
+  };
   var defaultOptions = {
     pointerX: 0,
     pointerY: 0,
@@ -24,7 +24,7 @@
     metaKey: false,
     bubbles: true,
     cancelable: true
-  }
+  };
   
   Event.simulate = function(element, eventName) {
     var options = Object.extend(Object.clone(defaultOptions), arguments[2] || { });


### PR DESCRIPTION
NetBeans complains: 
`Expected semicolon ; after "}" `
on var declarations that don't close with ;

js formatting and folding breaks past that point.